### PR TITLE
use syslog-ng internal() logger

### DIFF
--- a/r2s/extensions/proofpoint/pcasb/alerts_api_adaptor.py
+++ b/r2s/extensions/proofpoint/pcasb/alerts_api_adaptor.py
@@ -21,8 +21,8 @@ class PCASBAlertsAPIAdaptor(R2SAPIAdaptor):
         r = requests.post(self.auth_url,json=self.auth_body, headers=self.auth_headers)
         _print("Auth request executed")
         if r.status_code != 200 :
-            _print('Got non 200 response code: ' + str(r.status_code))
-            _print('Response body: ' + r.text)
+            logger.error('Got non 200 response code: ' + str(r.status_code))
+            logger.error('Response body: ' + r.text)
             r.raise_for_status()
         self.auth_token = r.json()['auth_token']
         _print('Access Token was refreshed successfully.')
@@ -37,8 +37,8 @@ class PCASBAlertsAPIAdaptor(R2SAPIAdaptor):
             _print('The Auth Token was probably expired.')
             self.auth_token = None
         else:
-            _print('Error Response code: ' + str(response.status_code))
-            _print('Error Response body: ' + response.text)
+            logger.error('Error Response code: ' + str(response.status_code))
+            logger.error('Error Response body: ' + response.text)
 
     def fetchItems(self, page_num):
         headers = self.getAuthHeaders()
@@ -52,6 +52,6 @@ class PCASBAlertsAPIAdaptor(R2SAPIAdaptor):
             else:
                 return response.json()['alerts']
         except Exception as ex:
-            _print('Error while trying to fetch items.')
-            _print(ex)
+            logger.error('Error while trying to fetch items.')
+            logger.error(ex)
             return None

--- a/r2s/extensions/proofpoint/pcasb/alerts_formatter.py
+++ b/r2s/extensions/proofpoint/pcasb/alerts_formatter.py
@@ -24,7 +24,7 @@ class PCASBAlertsFormatter(R2SItemFormatter):
             for (key,val) in leef_attributes.items(): leef_body += (key + '=' + val + '\t')
             return leef_body
         except Exception as ex:
-            _print(ex)
+            logger.error(ex)
             return ''
             
 
@@ -66,35 +66,35 @@ class PCASBAlertsFormatter(R2SItemFormatter):
         try:
             return self.item['related_events'][0]['user_email']
         except:
-            _print('could not extract user email from item id: ' + self.item['id'])
+            logger.error('could not extract user email from item id: ' + self.item['id'])
             return 'USER_NAME_EXTRACT_FAIL'
     
     def getCloudServiceName(self):
         try:
             return self.item['related_events'][0]['cloud_service']
         except:
-            _print('could not extract cloud service name from item ' + self.item['id'])
+            logger.error('could not extract cloud service name from item ' + self.item['id'])
             return 'CLOUD_SERVICE_EXTRACT_FAIL'
     
     def getClassification(self):
         try:
             return self.item['related_events'][0]['event_classification']['category']
         except:
-            _print("could not extract the related event's category from item " + self.item['id'])
+            logger.error("could not extract the related event's category from item " + self.item['id'])
             return 'CLASSIFICATION_EXTRACT_FAIL'
     
     def getSubClassification(self):
         try:
             return self.item['related_events'][0]['event_classification']['sub_category']
         except:
-            _print("could not extract the related event's sub category from item " + self.item['id'])
+            logger.error("could not extract the related event's sub category from item " + self.item['id'])
             return 'SUB_CLASSIFICATION_EXTRACT_FAIL'
 
     def getThreat(self):
         try:
             return self.item['related_events'][0]['event_classification']['threat']
         except:
-            _print("could not extract the related event's threat from item " + self.item['id'])
+            logger.error("could not extract the related event's threat from item " + self.item['id'])
             return 'THREAT_EXTRACT_FAIL'
     
     def buildMessage(self):

--- a/r2s/paginator.py
+++ b/r2s/paginator.py
@@ -15,8 +15,8 @@ class Paginator:
             _print('about to load formatters')
             self.formatter = self.loadFormatter(options)
         except Exception as ex:
-            _print(ex)
-            _print('could not initialize Paginator.')
+            logger.error(ex)
+            logger.error('could not initialize Paginator.')
             raise
         if api_adaptor is not None:
             self.api_adaptor = api_adaptor
@@ -70,7 +70,7 @@ class Paginator:
             if item.getID() != self.state.last_item_id:
                 filtered_items.append(item)
             else:
-                #_print('Current Record ID: ' + item.getID() + ' matched last record id from state: ' + self.state.last_item_id )
+                logger.debug('Current Record ID: ' + item.getID() + ' matched last record id from state: ' + self.state.last_item_id )
                 self.state.setLastItemId(self.current_item_id)
                 self.is_end = True
                 break
@@ -87,7 +87,7 @@ class Paginator:
             try:
                 items = self.formatter.wrapItems(response_json)
             except Exception as ex:
-                _print(ex)
+                logger.error(ex)
                 items = None
             return self.filterItems(items)
         else:

--- a/r2s/source.py
+++ b/r2s/source.py
@@ -17,7 +17,7 @@ class REST2SyslogSource(LogSource):
             self.exit = False
             return True
         except:
-            _print('configuration of REST2Syslog Source (R2S) is incomplete or malformed. Please reffer to the R2S Wiki for more details.')
+            logger.error('configuration of REST2Syslog Source (R2S) is incomplete or malformed. Please reffer to the R2S Wiki for more details.')
             return False
 
     def request_exit(self): # mandatory
@@ -30,8 +30,8 @@ class REST2SyslogSource(LogSource):
                 time.sleep(self.interval)
                 self.doWork()
             except Exception as e:
-                _print('Error while trying to fetch alerts.')
-                _print(e)
+                logger.error('Error while trying to fetch alerts.')
+                logger.error(e)
 
     def sendItems(self,items):
         for item in items:            

--- a/r2s/state.py
+++ b/r2s/state.py
@@ -16,12 +16,12 @@ class State:
                 else:
                     _print('restored state was empty.')
         except Exception as e:
-            _print('No REST2Syslog State. Creating a new instance.'+ str(e))
+            logger.error('No REST2Syslog State. Creating a new instance.'+ str(e))
             self.last_item_id = last_item_id
 
     def setLastItemId(self,last_item_id):
         if(last_item_id != ''):
-            #_print('storing new last item id:' + last_item_id)
+            logger.debug('storing new last item id:' + last_item_id)
             self.last_item_id = last_item_id
             self.persist()
 
@@ -30,7 +30,7 @@ class State:
             with open(self.persist_path, 'wb') as f:
                 pickle.dump(self, f)
         except Exception as e:
-            _print('Error while trying to store REST2Syslog State: ' + str(e))
+            logger.error('Error while trying to store REST2Syslog State: ' + str(e))
 
 
 

--- a/r2s/utils.py
+++ b/r2s/utils.py
@@ -1,5 +1,6 @@
-import sys
+from syslogng import Logger
+
+logger = syslogng.Logger()
 
 def _print(msg):
-    print(msg)
-    sys.stdout.flush()
+    logger.info(msg)


### PR DESCRIPTION
This logger uses either `system()` source or prints to stderr in a syslog-ng way, also uses the options `--debug, --trace, ...` specified when starting syslog-ng.

Everything is replaced with `info` level, expect error handling branches.

Disclaimer: I did not try this out :(